### PR TITLE
[08] ZeRO-2 chunked reduce-scatter and checkpoint reliability

### DIFF
--- a/nmoe/opt.py
+++ b/nmoe/opt.py
@@ -283,7 +283,8 @@ def update_lr(optimizer: torch.optim.Optimizer, dense_groups: list[dict], step: 
     else:
       g['lr'] = lr_dense
 
-  return float(optimizer.param_groups[0]['lr'])
+  # Return the dense LR for logging (backward compatible with older single-LR configs).
+  return float(lr_dense)
 
 
 def step(model: torch.nn.Module, optimizer: torch.optim.Optimizer, dense_groups: list[dict], zero2_state: dict, cfg: Config, world: int) -> None:

--- a/nmoe/quant.py
+++ b/nmoe/quant.py
@@ -9,7 +9,7 @@ Output formats:
 from __future__ import annotations
 
 import torch
-from nmoe.rdep import _C
+from nmoe.csrc import rdep as _C  # Direct import to avoid heavy runtime deps / circular imports
 
 
 def quantize_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/nmoe/train.py
+++ b/nmoe/train.py
@@ -201,16 +201,26 @@ def main():
 
   # Apply CLI overrides (--key=value)
   for arg in sys.argv[2:]:
-    if arg.startswith('--') and '=' in arg:
-      key, val = arg[2:].split('=', 1)
-      # Parse booleans and ints
-      if val.lower() in ('true', 'false'):
-        val = val.lower() == 'true'
-      elif val.lstrip('-').isdigit():
-        val = int(val)
-      elif val.replace('.', '', 1).lstrip('-').isdigit():
-        val = float(val)
-      cfg_dict[key] = val
+    if not arg.startswith('--'):
+      continue
+
+    # Support boolean flags without '=' for common toggles.
+    if '=' not in arg:
+      if arg == '--resume':
+        cfg_dict['resume'] = True
+      elif arg == '--no-resume':
+        cfg_dict['resume'] = False
+      continue
+
+    key, val = arg[2:].split('=', 1)
+    # Parse booleans and ints
+    if val.lower() in ('true', 'false'):
+      val = val.lower() == 'true'
+    elif val.lstrip('-').isdigit():
+      val = int(val)
+    elif val.replace('.', '', 1).lstrip('-').isdigit():
+      val = float(val)
+    cfg_dict[key] = val
 
   cfg = Config(**cfg_dict)
 


### PR DESCRIPTION
## Summary

ZeRO-2 memory optimization and checkpoint reliability improvements.

## Changes

- **Chunked reduce-scatter** (`nmoe/zero2.py`): Replace monolithic `flat_grad` with `rs_in`/`rs_out` buffers. Configurable via `NMOE_ZERO2_RS_CHUNK_MB` (default 2GB).
- **Checkpoint reliability** (`nmoe/checkpoint.py`): Eager CPU copy before background queue; clean thread shutdown.
- **CLI improvement** (`nmoe/train.py`): Support `--resume` / `--no-resume` boolean flags.
- **Fixes**: Direct csrc import in quant.py, opt-in blockscaled buffers in rdep.py.

## PR Attestation

```yaml
nmoe_pr:
  issue: 08
  baseline_sha: 0fee6e5
  risk: warm

gates_passed:
  tier_a:
    - cpu:syntax
  tier_b: []
```

## Test plan

- [ ] Tier A: syntax check
- [ ] Tier B: hot_path_min (moonlet_1x10, moonlight_8x20)
- [ ] Checkpoint resume test: save at step 50, resume to step 100