### PR TITLE
[07] Eval framework: choice-based + generation-based evals

### DIFF
--- a/nmoe/eval/__init__.py
+++ b/nmoe/eval/__init__.py
@@ -1,0 +1,8 @@
+"""
+nmoe.eval: evaluation utilities.
+
+Issue [07] adds:
+- Choice-based eval (fast forward-only scoring): `nmoe.eval.choices`
+- Generation-based eval (standalone): `python -m nmoe.eval.run_gen`
+"""
+

--- a/nmoe/eval/choices.py
+++ b/nmoe/eval/choices.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+"""
+Choice-based evaluation (MMLU, ARC, HellaSwag, ...).
+
+Design constraints (Issue [07]):
+- Must not materialize (seq, vocab) log_softmax/logits for vocab≈200k.
+- Must keep all ranks in lockstep by construction (no barriers in inner loops).
+"""
+
+import argparse
+import math
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import torch
+import torch.distributed as dist
+import tiktoken
+
+from nmoe.eval.adapters import iter_choices
+
+
+BASELINES: dict[str, float] = {
+    "ARC-Easy": 0.25,
+    "ARC-Challenge": 0.25,
+    "HellaSwag": 0.25,
+    "MMLU": 0.25,
+    "MMLU-pro": 0.10,  # 10 choices
+    "OpenBookQA": 0.25,
+    "WinoGrande": 0.5,
+    "BoolQ": 0.5,
+    "COPA": 0.5,
+}
+
+DEFAULT_TASKS: list[tuple[str, str]] = [
+    ("MMLU", "hf:cais/mmlu:all:dev"),
+    ("MMLU-pro", "hf:TIGER-Lab/MMLU-Pro:test"),
+]
+
+FULL_TASKS: list[tuple[str, str]] = DEFAULT_TASKS + [
+    ("ARC-Easy", "hf:allenai/ai2_arc:ARC-Easy:test"),
+    ("ARC-Challenge", "hf:allenai/ai2_arc:ARC-Challenge:test"),
+    ("HellaSwag", "hf:Rowan/hellaswag:validation"),
+    ("OpenBookQA", "hf:allenai/openbookqa:main:test"),
+    ("WinoGrande", "hf:allenai/winogrande:winogrande_debiased:validation"),
+    ("BoolQ", "hf:google/boolq:validation"),
+    ("COPA", "hf:super_glue:copa:validation"),
+]
+
+
+@dataclass(frozen=True)
+class ChoiceEvalStats:
+    correct: int
+    total: int
+
+
+def _centered_acc(acc: float, baseline: float) -> float:
+    if baseline >= 1.0:
+        return 0.0
+    return max(0.0, min(1.0, (acc - baseline) / (1.0 - baseline)))
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return int(((x + multiple - 1) // multiple) * multiple)
+
+
+@torch.no_grad()
+def _forward_hidden(model: torch.nn.Module, tokens: torch.Tensor) -> torch.Tensor:
+    """Forward model up to final norm (no lm_head), returning hidden [B,T,D]."""
+    # This replicates nmoe.model.Transformer.forward() up to norm_f, without lm_head.
+    if not hasattr(model, "embedding") or not hasattr(model, "blocks") or not hasattr(model, "norm"):
+        raise TypeError("model must be an nmoe.model.Transformer-like module")
+    if not hasattr(model, "rope"):
+        raise TypeError("model must have rope buffers (RotaryEmbedding)")
+
+    x = model.embedding(tokens) * float(getattr(model, "mup_scale_factor", 1.0))
+    seqlen = int(tokens.size(1))
+    cos = model.rope.cos[:seqlen].to(tokens.device)
+    sin = model.rope.sin[:seqlen].to(tokens.device)
+    for block in model.blocks:
+        x = block(x, cos, sin)
+    x = model.norm(x)
+    return x
+
+
+@torch.no_grad()
+def _logsumexp_vocab_chunked(
+    h: torch.Tensor,  # [N,D], float32
+    lm_head_weight: torch.Tensor,  # [V,D], bf16/fp16/fp32
+    *,
+    logits_scale: float,
+    chunk_size: int,
+) -> torch.Tensor:
+    """Compute logsumexp over vocab for each row of h without materializing (N,V)."""
+    if h.dim() != 2 or lm_head_weight.dim() != 2:
+        raise ValueError("expected h=[N,D], lm_head_weight=[V,D]")
+    if h.size(1) != lm_head_weight.size(1):
+        raise ValueError("hidden dim mismatch with lm_head weight")
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+
+    V = int(lm_head_weight.size(0))
+    out = None
+    for start in range(0, V, chunk_size):
+        end = min(V, start + chunk_size)
+        w = lm_head_weight[start:end].to(dtype=torch.float32)  # [C,D]
+        logits = (h @ w.t()) * logits_scale  # [N,C] fp32
+        lse = torch.logsumexp(logits, dim=-1)  # [N]
+        out = lse if out is None else torch.logaddexp(out, lse)
+    assert out is not None
+    return out
+
+
+@torch.no_grad()
+def _target_logits(
+    h: torch.Tensor,  # [N,D], float32
+    lm_head_weight: torch.Tensor,  # [V,D], bf16/fp16/fp32
+    target_ids: torch.Tensor,  # [N], int64
+    *,
+    logits_scale: float,
+) -> torch.Tensor:
+    w = lm_head_weight.index_select(0, target_ids).to(dtype=torch.float32)  # [N,D]
+    return (h * w).sum(dim=-1) * logits_scale  # [N]
+
+
+@torch.no_grad()
+def _score_option_logprob(
+    model: torch.nn.Module,
+    enc: tiktoken.Encoding,
+    prompt: str,
+    option: str,
+    *,
+    pad_to: int,
+    pad_token_id: int,
+    vocab_chunk_size: int,
+    compute_score: bool = True,
+) -> float:
+    """Return sum log p(option_tokens | prompt) for a single option."""
+    prompt_ids = enc.encode(prompt)
+    opt_ids = enc.encode(" " + option) if option else [pad_token_id]
+    if len(prompt_ids) < 1 or len(opt_ids) < 1:
+        return float("-inf")
+
+    # Full sequence used for causal next-token prediction.
+    full = prompt_ids + opt_ids
+    if len(full) > pad_to:
+        full = full[:pad_to]
+        opt_ids = opt_ids[: max(0, pad_to - len(prompt_ids))]
+    if len(full) < pad_to:
+        full = full + [pad_token_id] * (pad_to - len(full))
+
+    device = next(model.parameters()).device
+    tokens = torch.tensor(full, device=device, dtype=torch.long).unsqueeze(0)  # [1,T]
+    hidden = _forward_hidden(model, tokens)[0]  # [T,D]
+
+    if not compute_score:
+        return float("-inf")
+
+    lm_head = getattr(model, "lm_head", None)
+    if lm_head is None or not hasattr(lm_head, "weight"):
+        raise TypeError("model must expose lm_head.weight")
+
+    logits_scale = float(getattr(model, "logits_scale_factor", 1.0))
+    W = lm_head.weight.detach()  # [V,D]
+
+    # Positions predicting option tokens: pos = prompt_len + j - 1
+    prompt_len = len(prompt_ids)
+    opt_len = len(opt_ids)
+    if opt_len <= 0 or prompt_len <= 0:
+        return float("-inf")
+    pos0 = prompt_len - 1
+    pos = torch.arange(pos0, pos0 + opt_len, device=device, dtype=torch.long)
+    # If truncated, guard
+    pos = pos[pos < pad_to]
+    if pos.numel() == 0:
+        return float("-inf")
+
+    target = torch.tensor(opt_ids[: pos.numel()], device=device, dtype=torch.long)
+    h = hidden.index_select(0, pos).to(dtype=torch.float32)  # [N,D]
+
+    lse = _logsumexp_vocab_chunked(h, W, logits_scale=logits_scale, chunk_size=vocab_chunk_size)
+    tgt = _target_logits(h, W, target, logits_scale=logits_scale)
+    return float((tgt - lse).sum().item())
+
+
+def _all_reduce_sum_i64(x: int, device: torch.device) -> int:
+    if not (dist.is_available() and dist.is_initialized()):
+        return int(x)
+    t = torch.tensor([int(x)], device=device, dtype=torch.long)
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    return int(t.item())
+
+
+@torch.no_grad()
+def eval_task(
+    model: torch.nn.Module,
+    enc: tiktoken.Encoding,
+    task_name: str,
+    source: str,
+    *,
+    max_examples: int,
+    rank: int,
+    world: int,
+    vocab_chunk_size: int,
+) -> dict[str, float]:
+    model_was_training = model.training
+    model.eval()
+    device = next(model.parameters()).device
+
+    examples = list(iter_choices(task_name, source, max_examples))
+    if not examples:
+        raise RuntimeError(f"no examples produced for task='{task_name}' source='{source}'")
+
+    # Compute padding targets from the shared example list (deterministic across ranks).
+    max_options = 1
+    max_seq = 2
+    for ex in examples:
+        prompt_ids = enc.encode(ex["prompt"])
+        max_options = max(max_options, len(ex["options"]))
+        for opt in ex["options"]:
+            opt_ids = enc.encode(" " + str(opt))
+            max_seq = max(max_seq, len(prompt_ids) + len(opt_ids))
+    pad_to = _round_up(max_seq, 128)
+
+    max_per_rank = (len(examples) + world - 1) // world
+    my = examples[rank::world]
+    num_real = len(my)
+
+    pad_token_id = int(getattr(getattr(model, "config", None), "eos_token_id", 0))
+
+    correct = 0
+    total = 0
+    dummy = examples[0]
+
+    for i in range(max_per_rank):
+        ex = my[i] if i < num_real else dummy
+        prompt = str(ex["prompt"])
+        options = [str(o) for o in ex["options"]]
+        label = int(ex["label"])
+
+        # Ensure fixed number of forwards per-example across ranks by padding options.
+        best_idx = 0
+        best_score = -math.inf
+        for j in range(max_options):
+            is_real_opt = j < len(options)
+            opt = options[j] if is_real_opt else ""
+            score = _score_option_logprob(
+                model,
+                enc,
+                prompt,
+                opt,
+                pad_to=pad_to,
+                pad_token_id=pad_token_id,
+                vocab_chunk_size=vocab_chunk_size,
+                compute_score=is_real_opt,
+            )
+            if score > best_score:
+                best_score = score
+                best_idx = j
+
+        if i < num_real:
+            correct += int(best_idx == label)
+            total += 1
+
+    correct = _all_reduce_sum_i64(correct, device)
+    total = _all_reduce_sum_i64(total, device)
+    acc = (correct / total) if total > 0 else 0.0
+    centered = _centered_acc(acc, BASELINES.get(task_name, 0.25))
+
+    if model_was_training:
+        model.train()
+    return {"acc": float(acc), "centered_acc": float(centered), "n": float(total)}
+
+
+def run_eval(
+    model: torch.nn.Module,
+    cfg,
+    rank: int,
+    world: int,
+    *,
+    max_examples: int = 500,
+    tasks: Optional[list[tuple[str, str]]] = None,
+    vocab_chunk_size: int = 4096,
+) -> dict[str, dict[str, float]]:
+    """Run choice-based eval; all ranks must call together when distributed."""
+    if world > 1 and not (dist.is_available() and dist.is_initialized()):
+        raise RuntimeError("world>1 requires torch.distributed to be initialized (run under torchrun)")
+
+    tok_name = str(getattr(cfg, "tokenizer", "o200k_harmony"))
+    enc = tiktoken.get_encoding(tok_name)
+    chosen = DEFAULT_TASKS if tasks is None else tasks
+
+    out: dict[str, dict[str, float]] = {}
+    for task_name, source in chosen:
+        try:
+            out[task_name] = eval_task(
+                model,
+                enc,
+                task_name,
+                source,
+                max_examples=int(max_examples),
+                rank=int(rank),
+                world=int(world),
+                vocab_chunk_size=int(vocab_chunk_size),
+            )
+        except Exception as e:
+            out[task_name] = {"acc": 0.0, "centered_acc": 0.0, "n": 0.0, "error": str(e)}
+            if rank == 0:
+                print(f"[eval/choices] task '{task_name}' failed: {e}")
+    return out
+
+
+def format_results(results: dict[str, dict[str, float]]) -> str:
+    parts = []
+    for name, r in results.items():
+        if "error" in r:
+            parts.append(f"{name}: ERROR")
+            continue
+        acc = float(r.get("acc", 0.0))
+        centered = float(r.get("centered_acc", 0.0))
+        n = int(r.get("n", 0.0))
+        parts.append(f"{name}: acc={acc:.3f} centered={centered:.3f} n={n}")
+    return " | ".join(parts)
+
+
+def _parse_tasks_arg(tasks: str) -> list[tuple[str, str]]:
+    if tasks.lower() in ("default", "defaults"):
+        return list(DEFAULT_TASKS)
+    if tasks.lower() in ("full", "all"):
+        return list(FULL_TASKS)
+    out: list[tuple[str, str]] = []
+    for item in tasks.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        matches = [t for t in FULL_TASKS if t[0].lower() == item.lower()]
+        if not matches:
+            raise ValueError(f"unknown task '{item}' (use --list-tasks)")
+        out.append(matches[0])
+    if not out:
+        raise ValueError("no tasks selected")
+    return out
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    p = argparse.ArgumentParser(description="Choice-based evaluation (fast forward-only scoring)")
+    p.add_argument("--list-tasks", action="store_true", help="Print available task names and exit")
+    p.add_argument("--tasks", type=str, default="default", help="default|full|comma-separated task names")
+    p.add_argument("--max-examples", type=int, default=200)
+    p.add_argument("--vocab-chunk-size", type=int, default=4096)
+    p.add_argument("--snapshot", type=str, default="", help="Path to eval snapshot (.pt) with config+model_state")
+    args = p.parse_args(argv)
+
+    if args.list_tasks:
+        for name, src in FULL_TASKS:
+            print(f"{name}\t{src}")
+        return
+
+    if not args.snapshot:
+        raise SystemExit("--snapshot is required for CLI mode")
+
+    import torch.distributed as dist  # local import to keep module import light
+    if "RANK" in __import__("os").environ and not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world = dist.get_world_size() if dist.is_initialized() else 1
+
+    obj = torch.load(args.snapshot, map_location="cpu")
+    cfg_dict = obj.get("config", {})
+    from nmoe.config import Config
+    from nmoe.model import Transformer
+
+    cfg = Config(**cfg_dict)
+    model = Transformer(cfg).cuda()
+    model.load_state_dict(obj.get("model_state", {}), strict=False)
+
+    tasks = _parse_tasks_arg(args.tasks)
+    res = run_eval(
+        model,
+        cfg,
+        rank,
+        world,
+        max_examples=args.max_examples,
+        tasks=tasks,
+        vocab_chunk_size=args.vocab_chunk_size,
+    )
+    if rank == 0:
+        print(format_results(res))
+
+
+if __name__ == "__main__":
+    main()

--- a/nmoe/eval/execution.py
+++ b/nmoe/eval/execution.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    ok: bool
+    stdout: str
+    stderr: str
+    returncode: int
+
+    @property
+    def success(self) -> bool:
+        # Backward-compatible alias used by older task implementations.
+        return bool(self.ok)
+
+
+def _strip_code_fences(s: str) -> str:
+    t = s.strip()
+    if t.startswith("```"):
+        # Remove first fence line and trailing fence if present.
+        lines = t.splitlines()
+        if lines:
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        return "\n".join(lines).strip() + "\n"
+    return t + ("\n" if not t.endswith("\n") else "")
+
+
+def run_python(
+    code: str,
+    *,
+    timeout_s: float = 5.0,
+    python: str = "python",
+    cwd: Optional[str] = None,
+) -> ExecResult:
+    """Execute code in a subprocess with a timeout.
+
+    This is a pragmatic sandbox for HumanEval-style unit tests. It is not a
+    perfect security boundary; it is intended for trusted evaluation inputs.
+    """
+    with tempfile.TemporaryDirectory(prefix="nmoe_eval_") as d:
+        path = Path(d) / "prog.py"
+        path.write_text(code, encoding="utf-8")
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        try:
+            p = subprocess.run(
+                [python, str(path)],
+                cwd=cwd or d,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=timeout_s,
+                check=False,
+            )
+            return ExecResult(ok=(p.returncode == 0), stdout=p.stdout, stderr=p.stderr, returncode=p.returncode)
+        except subprocess.TimeoutExpired as e:
+            return ExecResult(ok=False, stdout=e.stdout or "", stderr=(e.stderr or "") + "\nTIMEOUT\n", returncode=124)
+
+
+def humaneval_check(
+    prompt: str,
+    completion: str,
+    tests: str,
+    *,
+    timeout_s: float = 5.0,
+) -> ExecResult:
+    """Run HumanEval tests for a prompt+completion."""
+    code = prompt + _strip_code_fences(completion) + "\n" + tests + "\n"
+    return run_python(code, timeout_s=timeout_s)
+
+
+def execute_code(code: str, timeout: float = 5.0) -> ExecResult:
+    """Backward-compatible entrypoint for HumanEval task implementations."""
+    return run_python(code, timeout_s=float(timeout))

--- a/nmoe/eval/run_gen.py
+++ b/nmoe/eval/run_gen.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+"""
+Generation-based eval runner (GSM8K / HumanEval / GPQA).
+
+Issue [07] intent:
+- No dependency on `nmoe.serve.*` (standalone, model-direct generation).
+- Distributed-safe: all ranks participate and remain in lockstep by construction.
+- Prompt-length semantics preserved (explicit length tracking; no "real-token padding" bugs).
+"""
+
+import argparse
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+import torch.distributed as dist
+import tiktoken
+
+from nmoe.metrics import start_metrics, stop_metrics
+
+from nmoe.eval.tasks.gsm8k import GSM8K
+from nmoe.eval.tasks.gpqa import GPQA
+from nmoe.eval.tasks.humaneval import HumanEval
+
+
+TASKS: dict[str, type] = {
+    "GSM8K": GSM8K,
+    "HumanEval": HumanEval,
+    "GPQA": GPQA,
+}
+
+
+def _init_dist() -> tuple[int, int]:
+    if "RANK" in os.environ and not dist.is_initialized():
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+        dist.init_process_group(backend=backend)
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    world = dist.get_world_size() if dist.is_initialized() else 1
+    return int(rank), int(world)
+
+
+def _print0(rank: int, *a: Any, **kw: Any) -> None:
+    if rank == 0:
+        print(*a, **kw)
+
+
+def _load_config(path: str):
+    import tomllib
+    from nmoe.config import Config
+
+    with open(path, "rb") as f:
+        cfg_dict = tomllib.load(f)
+    return Config(**cfg_dict)
+
+
+def _load_snapshot(path: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    obj = torch.load(path, map_location="cpu", weights_only=False)
+    cfg_dict = obj.get("config", {})
+    model_state = obj.get("model_state", {})
+    if not isinstance(cfg_dict, dict) or not isinstance(model_state, dict):
+        raise ValueError("snapshot must contain dict fields 'config' and 'model_state'")
+    return cfg_dict, model_state
+
+
+@torch.no_grad()
+def _forward_hidden(model: torch.nn.Module, tokens: torch.Tensor) -> torch.Tensor:
+    if not hasattr(model, "embedding") or not hasattr(model, "blocks") or not hasattr(model, "norm"):
+        raise TypeError("model must be an nmoe.model.Transformer-like module")
+    if not hasattr(model, "rope"):
+        raise TypeError("model must have rope buffers (RotaryEmbedding)")
+
+    x = model.embedding(tokens) * float(getattr(model, "mup_scale_factor", 1.0))
+    seqlen = int(tokens.size(1))
+    cos = model.rope.cos[:seqlen].to(tokens.device)
+    sin = model.rope.sin[:seqlen].to(tokens.device)
+    for block in model.blocks:
+        x = block(x, cos, sin)
+    x = model.norm(x)
+    return x
+
+
+@torch.no_grad()
+def _argmax_vocab_chunked(
+    h: torch.Tensor,  # [D] fp32
+    lm_head_weight: torch.Tensor,  # [V,D]
+    *,
+    logits_scale: float,
+    chunk_size: int,
+) -> int:
+    V = int(lm_head_weight.size(0))
+    best_val = None
+    best_idx = 0
+    for start in range(0, V, chunk_size):
+        end = min(V, start + chunk_size)
+        w = lm_head_weight[start:end].to(dtype=torch.float32)  # [C,D]
+        logits = (w @ h) * logits_scale  # [C]
+        val, idx = torch.max(logits, dim=0)
+        if best_val is None or float(val) > float(best_val):
+            best_val = val
+            best_idx = start + int(idx.item())
+    return int(best_idx)
+
+
+@torch.no_grad()
+def _topk_vocab_chunked(
+    h: torch.Tensor,  # [D] fp32
+    lm_head_weight: torch.Tensor,  # [V,D]
+    *,
+    logits_scale: float,
+    k: int,
+    chunk_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    V = int(lm_head_weight.size(0))
+    k = max(1, int(k))
+    best_vals = None
+    best_idx = None
+    for start in range(0, V, chunk_size):
+        end = min(V, start + chunk_size)
+        w = lm_head_weight[start:end].to(dtype=torch.float32)  # [C,D]
+        logits = (w @ h) * logits_scale  # [C]
+        kk = min(k, int(logits.numel()))
+        vals, idx = torch.topk(logits, k=kk)
+        idx = idx + start
+        if best_vals is None:
+            best_vals, best_idx = vals, idx
+        else:
+            cat_vals = torch.cat([best_vals, vals], dim=0)
+            cat_idx = torch.cat([best_idx, idx], dim=0)
+            kk = min(k, int(cat_vals.numel()))
+            vals2, sel = torch.topk(cat_vals, k=kk)
+            best_vals = vals2
+            best_idx = cat_idx.index_select(0, sel)
+    assert best_vals is not None and best_idx is not None
+    return best_vals, best_idx
+
+
+@torch.no_grad()
+def _generate_lockstep(
+    model: torch.nn.Module,
+    enc: tiktoken.Encoding,
+    prompt: str,
+    *,
+    pad_to: int,
+    max_new_tokens: int,
+    temperature: float,
+    top_k: int,
+    pad_token_id: int,
+) -> str:
+    """Generate `max_new_tokens` tokens with explicit prompt length handling.
+
+    All ranks must call this with identical `pad_to` and `max_new_tokens` to
+    preserve distributed lockstep.
+    """
+    device = next(model.parameters()).device
+    prompt_ids = enc.encode(prompt)
+    if not prompt_ids:
+        prompt_ids = [pad_token_id]
+    if len(prompt_ids) >= pad_to:
+        prompt_ids = prompt_ids[: pad_to - 1]
+
+    tokens = torch.full((1, pad_to), pad_token_id, device=device, dtype=torch.long)
+    plen = len(prompt_ids)
+    tokens[0, :plen] = torch.tensor(prompt_ids, device=device, dtype=torch.long)
+    cur_len = plen
+
+    generated: list[int] = []
+    lm_head = getattr(model, "lm_head", None)
+    if lm_head is None or not hasattr(lm_head, "weight"):
+        raise TypeError("model must expose lm_head.weight")
+    W = lm_head.weight.detach()
+    logits_scale = float(getattr(model, "logits_scale_factor", 1.0))
+    vocab_chunk = 4096
+    for _ in range(int(max_new_tokens)):
+        hidden = _forward_hidden(model, tokens)  # [1,T,D]
+        h = hidden[0, cur_len - 1].to(dtype=torch.float32)  # [D]
+        if temperature <= 0.0 or int(top_k) <= 1:
+            next_id = _argmax_vocab_chunked(h, W, logits_scale=logits_scale, chunk_size=vocab_chunk)
+        else:
+            vals, idx = _topk_vocab_chunked(
+                h, W, logits_scale=logits_scale, k=int(top_k), chunk_size=vocab_chunk
+            )
+            scaled = vals / float(temperature)
+            probs = torch.softmax(scaled, dim=-1)
+            choice = int(torch.multinomial(probs, num_samples=1).item())
+            next_id = int(idx[choice].item())
+        if cur_len < pad_to:
+            tokens[0, cur_len] = int(next_id)
+        generated.append(int(next_id))
+        cur_len = min(cur_len + 1, pad_to)
+
+    return enc.decode(generated)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    p = argparse.ArgumentParser(description="Run generation-based evaluations")
+    p.add_argument("--list-tasks", action="store_true", help="List tasks and exit")
+    p.add_argument("--task", type=str, default="", help="Task name (use --list-tasks)")
+    p.add_argument("--config", type=str, default="", help="Training config TOML (for model architecture + tokenizer)")
+    p.add_argument("--checkpoint", type=str, default="", help="Optional eval snapshot (.pt) with config+model_state")
+    p.add_argument("--max-problems", type=int, default=None)
+    p.add_argument("--max-new-tokens", type=int, default=256)
+    p.add_argument("--temperature", type=float, default=0.0)
+    p.add_argument("--top-k", type=int, default=1)
+    p.add_argument("--out-dir", type=str, default="", help="Optional output directory for summary.json")
+    args = p.parse_args(argv)
+
+    if args.list_tasks:
+        for name in sorted(TASKS.keys()):
+            print(name)
+        return
+
+    if not args.task:
+        raise SystemExit("--task is required (or use --list-tasks)")
+    if args.task not in TASKS:
+        raise SystemExit(f"unknown task '{args.task}' (use --list-tasks)")
+
+    rank, world = _init_dist()
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required for nmoe.eval.run_gen (B200-targeted); run in the training container")
+
+    # Load cfg/model
+    cfg = None
+    state = None
+    if args.checkpoint:
+        cfg_dict, state = _load_snapshot(args.checkpoint)
+        from nmoe.config import Config
+        cfg = Config(**cfg_dict)
+    elif args.config:
+        cfg = _load_config(args.config)
+    else:
+        raise SystemExit("must pass --checkpoint (eval snapshot) or --config (training config TOML)")
+
+    from nmoe.model import Transformer
+
+    model = Transformer(cfg).cuda()
+    model.init_weights()
+    if state is not None:
+        model.load_state_dict(state, strict=False)
+    model.eval()
+
+    enc = tiktoken.get_encoding(str(getattr(cfg, "tokenizer", "o200k_harmony")))
+    pad_token_id = int(getattr(cfg, "eos_token_id", 0))
+
+    task = TASKS[args.task]()
+    max_problems = args.max_problems
+    n = len(task) if max_problems is None else min(int(max_problems), len(task))
+
+    # Shared padding length across all ranks for lockstep.
+    prompts = [task.format_prompt(task[i]) for i in range(n)]
+    max_prompt = max(len(enc.encode(p)) for p in prompts) if prompts else 1
+    pad_to = int(((max_prompt + int(args.max_new_tokens) + 127) // 128) * 128)
+
+    my_idx = list(range(rank, n, world))
+    max_per_rank = (n + world - 1) // world
+
+    metrics_ctx = start_metrics(run_id=os.getenv("NMOE_RUN", "eval"), metrics_dir=getattr(cfg, "metrics_dir", None))
+    passed = 0
+    total = 0
+    dummy_ex = task[0] if n > 0 else {}
+
+    try:
+        for it in range(max_per_rank):
+            if it < len(my_idx):
+                ex = task[my_idx[it]]
+                prompt = task.format_prompt(ex)
+                real = True
+            else:
+                ex = dummy_ex
+                prompt = task.format_prompt(ex) if n > 0 else ""
+                real = False
+
+            completion = _generate_lockstep(
+                model,
+                enc,
+                prompt,
+                pad_to=pad_to,
+                max_new_tokens=int(args.max_new_tokens),
+                temperature=float(args.temperature),
+                top_k=int(args.top_k),
+                pad_token_id=pad_token_id,
+            )
+
+            if real:
+                ok = bool(task.evaluate(ex, completion))
+                passed += int(ok)
+                total += 1
+                if rank == 0:
+                    _print0(rank, f"\r{passed}/{total} ({100.0*passed/max(1,total):.2f}%)", end="", flush=True)
+
+        if rank == 0:
+            print()
+
+        if world > 1:
+            device = next(model.parameters()).device
+            t = torch.tensor([passed, total], device=device, dtype=torch.long)
+            dist.all_reduce(t, op=dist.ReduceOp.SUM)
+            passed, total = int(t[0].item()), int(t[1].item())
+
+        acc = (passed / total) if total > 0 else 0.0
+        _print0(rank, f"[eval/{args.task}] {passed}/{total} ({100.0*acc:.2f}%)")
+        if metrics_ctx.writer is not None and rank == 0:
+            metrics_ctx.writer.insert_many(
+                step=0,
+                items=[
+                    (f"eval_gen/{args.task}/acc", float(acc)),
+                    (f"eval_gen/{args.task}/passed", float(passed)),
+                    (f"eval_gen/{args.task}/total", float(total)),
+                ],
+            )
+
+        if rank == 0:
+            base = Path(args.out_dir) if args.out_dir else Path(str(getattr(cfg, "metrics_dir", "/data/metrics")))
+            out = base / "eval_gen" / str(os.getenv("NMOE_RUN", "eval")) / args.task
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "summary.json").write_text(
+                json.dumps(
+                    {
+                        "task": args.task,
+                        "acc": acc,
+                        "passed": passed,
+                        "total": total,
+                        "config": asdict(cfg),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+    finally:
+        stop_metrics(metrics_ctx)
+
+
+if __name__ == "__main__":
+    main()

--- a/nmoe/eval/tasks/gpqa.py
+++ b/nmoe/eval/tasks/gpqa.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+
+_CHOICE_RE = re.compile(r"\\b([A-D])\\b", re.IGNORECASE)
+
+
+def _extract_choice(text: str) -> Optional[str]:
+    m = _CHOICE_RE.search(text)
+    if not m:
+        return None
+    return m.group(1).upper()
+
+
+class GPQA:
+    name = "GPQA"
+
+    def __init__(self, *, split: str = "test"):
+        from datasets import load_dataset
+
+        try:
+            # Public, MC-formatted GPQA variant (no auth required).
+            self.ds = load_dataset("hendrydong/gpqa_diamond_mc", split=split)
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to load GPQA (HF dataset 'hendrydong/gpqa_diamond_mc'). "
+                "Verify internet/HF access and try again."
+            ) from e
+
+    def __len__(self) -> int:
+        return int(len(self.ds))
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        return dict(self.ds[int(idx)])
+
+    def format_prompt(self, ex: dict[str, Any]) -> str:
+        # Dataset encodes the full MC question+choices in a single "problem" field.
+        problem = str(ex.get("problem", "")).strip()
+        return f"{problem}\nAnswer (A-D):"
+
+    def evaluate(self, ex: dict[str, Any], completion: str) -> bool:
+        # Solution is typically like "\\boxed{D}".
+        gold_raw = str(ex.get("solution", "")).strip()
+        gold = _extract_choice(gold_raw)
+        pred = _extract_choice(completion)
+        return bool(gold is not None and pred is not None and pred == gold)

--- a/nmoe/eval/tasks/gsm8k.py
+++ b/nmoe/eval/tasks/gsm8k.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+
+_ANS_RE = re.compile(r"####\\s*([-+]?\\d+(?:\\.\\d+)?)")
+_NUM_RE = re.compile(r"[-+]?\\d+(?:\\.\\d+)?")
+
+
+def _extract_gold(answer: str) -> Optional[str]:
+    m = _ANS_RE.search(answer)
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
+def _extract_pred(text: str) -> Optional[str]:
+    # Prefer the final numeric-looking token.
+    nums = _NUM_RE.findall(text.replace(",", ""))
+    if not nums:
+        return None
+    return nums[-1].strip()
+
+
+class GSM8K:
+    name = "GSM8K"
+
+    def __init__(self, *, subset: str = "main", split: str = "test"):
+        from datasets import load_dataset
+
+        self.ds = load_dataset("openai/gsm8k", subset, split=split)
+
+    def __len__(self) -> int:
+        return int(len(self.ds))
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        return dict(self.ds[int(idx)])
+
+    def format_prompt(self, ex: dict[str, Any]) -> str:
+        q = str(ex.get("question", "")).strip()
+        return f"{q}\nAnswer:"
+
+    def evaluate(self, ex: dict[str, Any], completion: str) -> bool:
+        gold = _extract_gold(str(ex.get("answer", "")))
+        pred = _extract_pred(completion)
+        if gold is None or pred is None:
+            return False
+        try:
+            # GSM8K gold is effectively integer-valued.
+            return int(float(pred)) == int(float(gold))
+        except Exception:
+            return False

--- a/nmoe/eval/tasks/humaneval.py
+++ b/nmoe/eval/tasks/humaneval.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from nmoe.eval.execution import humaneval_check
+
+
+class HumanEval:
+    name = "HumanEval"
+
+    def __init__(self, *, split: str = "test"):
+        from datasets import load_dataset
+
+        self.ds = load_dataset("openai/openai_humaneval", split=split)
+
+    def __len__(self) -> int:
+        return int(len(self.ds))
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        return dict(self.ds[int(idx)])
+
+    def format_prompt(self, ex: dict[str, Any]) -> str:
+        return str(ex.get("prompt", ""))
+
+    def evaluate(self, ex: dict[str, Any], completion: str) -> bool:
+        prompt = str(ex.get("prompt", ""))
+        tests = str(ex.get("test", ""))
+        if not prompt or not tests:
+            return False
+        res = humaneval_check(prompt, completion, tests, timeout_s=10.0)
+        return bool(res.ok)


### PR DESCRIPTION
## Summary

Evaluation framework with two modes:
1. **Choice-based** (`nmoe/eval/choices.py`): Fast forward-only scoring (MMLU, ARC, HellaSwag, etc.)
2. **Generation-based** (`nmoe/eval/run_gen.py`): Model generation (GSM8K, HumanEval, GPQA)

## Key features

- Chunked logsumexp: avoids materializing `(seq, vocab)` logits for 200k vocab
- HF dataset adapters for all major benchmarks
- Multi-GPU eval with lockstep by construction
- Training integration via `eval_every` config

## Changes

- `nmoe/eval/choices.py` (392 lines) - choice-based eval runner
- `nmoe/eval/run_gen.py` (339 lines) - generation eval runner
- `nmoe/eval/adapters.py` - HF dataset adapters
- `nmoe/eval/execution.py` - code sandbox for HumanEval
- `nmoe/eval/tasks/` - task definitions (gsm8k, humaneval, gpqa)
- `nmoe/train.py` - eval integration

## PR Attestation

```yaml
nmoe_pr:
  issue: 07
  baseline_sha: 8203984
  risk: warm

gates_passed:
  tier_a:
    - cpu:syntax
  tier_b: []
```

## Test plan

- [ ] Tier A: syntax check
- [ ] Tier B: hot_path_min
- [ ] Manual: `python -m nmoe.train configs/moonlet.toml --steps=40 --eval_every=20`